### PR TITLE
fix(surrializable): support surrializable in array or objects

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,8 +7,8 @@ export function isInstanceOf(thing: unknown, whitelist: ReadonlyArray<ClassConst
 
 const SURRIALIZABLE_FN_NAME: keyof Surrializable = 'surrialize';
 
-export function isSurrializable(thing: object): thing is Surrializable {
-  return thing && typeof (thing as any)[SURRIALIZABLE_FN_NAME] === 'function';
+export function isSurrializable(thing: unknown): thing is Surrializable {
+  return thing && (typeof thing === 'object' || typeof thing === 'function') && typeof (thing as any)[SURRIALIZABLE_FN_NAME] === 'function';
 }
 
 function isEcmaScriptClass(constructor: ClassConstructor) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,10 @@ function stringifyObject(thing: any, knownClasses: ReadonlyArray<ClassConstructo
     // If the value is an object w/ a toJSON method, toJSON is called before
     // the replacer runs, so we use this[key] to get the non-JSON'd value.
     const origValue = this[key];
-    if (origValue !== thing && (isInstanceOf(origValue, BUILD_IN_SUPPORTED_CLASSES) || isInstanceOf(origValue, knownClasses))) {
+    if (
+      origValue !== thing &&
+      (isInstanceOf(origValue, BUILD_IN_SUPPORTED_CLASSES) || isInstanceOf(origValue, knownClasses) || isSurrializable(origValue))
+    ) {
       return `@__${UID}-${escapedValues.push(origValue) - 1}__@`;
     } else {
       return value;

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { expect } from 'chai';
-import { getParamList } from '../../src/helpers';
+import { getParamList, isSurrializable } from '../../src/helpers';
 
 describe('helpers', () => {
   describe('getParamList', () => {
@@ -7,6 +8,29 @@ describe('helpers', () => {
       expect(() => getParamList('error, this is not supported' as any)).throws(
         'Constructor function "undefined" could not be serialized. Class was defined as: error, this is not supported'
       );
+    });
+  });
+
+  describe(isSurrializable.name, () => {
+    class InstanceSurrialize {
+      surrialize() {}
+    }
+    class StaticSurrialize {
+      static surrialize() {}
+    }
+
+    [undefined, null, 42, 'foo', /bar/, class Person {}, function foo() {}, InstanceSurrialize, new StaticSurrialize()].forEach(val => {
+      it(`should be falsy for ${val}`, () => {
+        expect(isSurrializable(val)).not.ok;
+      });
+    });
+    function surrializable() {}
+    surrializable.surrialize = () => {};
+
+    [surrializable, { surrialize() {} }, new InstanceSurrialize(), StaticSurrialize].forEach(val => {
+      it(`should be true for ${val}`, () => {
+        expect(isSurrializable(val)).ok;
+      });
     });
   });
 });

--- a/test/unit/indexSpec.ts
+++ b/test/unit/indexSpec.ts
@@ -95,6 +95,17 @@ describe('surrial', () => {
       expect(output).deep.eq(input);
     });
 
+    it('should allow custom implementation using the `surrialize` function as part of an array or object', () => {
+      const foo = {
+        surrialize() {
+          return 'bar';
+        }
+      };
+
+      expect(serialize([foo])).eq('[bar]');
+      expect(serialize({ foo })).eq('{"foo":bar}');
+    });
+
     it('should not break for `surrialize` properties that are not functions', () => {
       class Person {
         public age: number;


### PR DESCRIPTION
The custom `surrializable` implementation only worked when the object provided itself implemented surrializable, not when it was was part of an array or object.